### PR TITLE
Add support for output file provenance

### DIFF
--- a/schema/pipeline-provenance.json
+++ b/schema/pipeline-provenance.json
@@ -1,264 +1,338 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "array",
-    "items": {
-	"anyOf": [
-	    {
-		"$ref": "#/definitions/PipelineProvenanceRecord",
-		"description": "A record of the pipeline that was run."
-	    },
-	    {
-		"$ref": "#/definitions/ProcessProvenanceRecord",
-		"description": "A record of a process that was run."
-	    },
-	    {
-		"$ref": "#/definitions/InputFileProvenanceRecord",
-		"description": "A record of an input file that was used."
-	    }
-	]
-    },
-    "definitions": {
-        "PipelineProvenanceRecord": {
-	    "title": "PipelineProvenanceRecord",
-            "type": "object",
-            "properties": {
-                "pipeline_name": {
-                    "type": "string",
-                    "description": "Name of the pipeline.",
-                    "examples": [
-                        "BCCDC-PHL/routine-assembly",
-                        "BCCDC-PHL/plasmid-screen"
-                    ]
-                },
-                "pipeline_version": {
-                    "type": "string",
-                    "description": "Version of the pipeline.",
-                    "examples": [
-                        "v0.1.0",
-                        "0.1.0",
-                        "1",
-                        "2.0-beta"
-                    ]
-                },
-		"timestamp_analysis_start": {
-		    "type": "string",
-		    "description": "Timestamp for the start of a pipeline run. ISO-8601-formatted date, followed by 'T' and a 24-hour timestamp, assumed to be in the local timezone if not specified. Timezone may be specified with an offset from UTC. Timestamp precision is not guaranteed.",
-		    "format": "date-time",
-		    "examples": [
-			"2021-12-06T16:12:31.252055",
-			"2022-01-12T01:22:51-08:00",
-			"2022-02-04T16:55:03.182-08:00"
-		    ]
-		}
-	    },
-	    "required": [
-		"pipeline_name",
-		"pipeline_version"
-	    ]
-	},
-	"ProcessProvenanceRecord": {
-	    "title": "ProcessProvenanceRecord",
-	    "type": "object",
-	    "properties": {
-		"process_name": {
-		    "type": "string",
-		    "description": "Name of the process.",
-		    "examples": [
-			"fastp",
-			"bwa_mem",
-			"samtools_mpileup",
-			"align_reads_to_ref",
-			"trim_reads",
-			"CALL_VARIANTS"
-		    ]
-		},
-		"tools": {
-		    "type": "array",
-		    "description": "The tools used to run the process.",
-		    "items": {
-			"$ref": "#/definitions/Tool"
-		    },
-		    "examples": [
-			[
-			    {
-				"tool_name": "fastp",
-				"tool_version": "0.20.0",
-				"subcommand": "trim",
-				"parameters": [
-				    {
-					"parameter": "cut_tail",
-					"value": null
-				    }
-				]
-			    }
-			],
-			[
-			    {
-				"tool_name": "bwa",
-				"tool_version": "0.7.17-r1188",
-				"subcommand": "mem",
-				"parameters": [
-				    {
-					"parameter": "exclude_flags",
-					"value": 1540
-				    },
-				    {
-					"parameter": "min_base_quality",
-					"value": 20
-				    }
-				]
-			    }
-			]
-		    ]
-		}
-	    },
-	    "required": [
-		"process_name"
-	    ]
-	},
-	"Tool": {
-	    "title": "Tool",
-	    "type": "object",
-	    "properties": {
-		"tool_name": {
-		    "type": "string",
-		    "description": "Name of the tool.",
-		    "examples": [
-			"fastp",
-			"bwa",
-			"samtools",
-			"bcftools",
-			"medaka"
-		    ]
-		},
-                "tool_version": {
-                    "type": "string",
-                    "description": "A number or string associated with a specific snapshot of the development state of a tool. Should (but may not always) map to a tagged release on GitHub or another version control system.",
-                    "examples": [
-                        "0.1.0",
-                        "v0.1.1",
-                        "1.1",
-                        "2",
-                        "0.7.17-r1188"
-                    ]
-                },
-		"subcommand": {
-		    "type": "string",
-		    "description": "Subcommand of the tool.",
-		    "examples": [
-			"mem",
-			"mpileup",
-			"filter"
-		    ]
-		},
-                "parameters": {
-                    "type": "array",
-		    "items": {
-			"$ref": "#/definitions/ToolParameter"
-		    },
-                    "description": "The specific invocation of a process may depend on values that can be varied. These values are the parameters to that process. Each parameter has a name and a value.",
-                    "examples": [
-                        [
-                            { 
-                                "parameter": "cut_tail",
-                                "value": null
-                            }
-                        ],
-                        [
-                            {
-                                "parameter": "exclude_flags",
-                                "value": 1540
-                            }
-                        ],
-                        [
-                            {
-                                "parameter": "min_base_quality",
-                                "value": 20
-                            }
-                        ],
-                        [
-                            {
-                                "parameter": "min_coverage",
-                                "value": 10
-                            }
-                        ]
-                    ]
-                }
-	    }
-	},
-	"ToolParameter": {
-	    "title": "ToolParameter",
-	    "type": "object",
-	    "properties": {
-		"parameter": {
-		    "type": "string",
-		    "description": "Name of the parameter.",
-		    "examples": [
-			"cut_tail",
-			"exclude_flags",
-			"min_base_quality",
-			"min_coverage"
-		    ]
-		},
-		"value": {
-		    "type": "string",
-		    "description": "Value of the parameter, or null if the parameter is a flag without a value.",
-		    "examples": [
-			"null",
-			"1540",
-			"20",
-			"10"
-		    ]
-		}
-	    },
-	    "required": [
-		"parameter"
-	    ]
-	},
-	"InputFileProvenanceRecord": {
-	    "title": "InputFileProvenanceRecord",
-	    "type": "object",
-	    "properties": {
-		"input_filename": {
-                    "type": "string",
-                    "description": "Filename of an input file.",
-                    "examples": [
-                        "sample-01_R1.fastq.gz",
-                        "sample-01_R2.fastq.gz",
-                        "ref.fa",
-                        "sample-01.bam",
-                        "sample-01.bam.bai"
-                    ]
-                },
-                "input_path": {
-                    "type": "string",
-                    "description": "Absolute path to an input file, at the time that the pipeline was invoked. May be invalid if the input file is moved or renamed after pipeline invocation.",
-                    "examples":[
-                        "/data/ref_data/ecoli.fa",
-                        "/data/sequence/miseq/210101_M00123_0123_000000000-ABC123/Data/Intensities/BaseCalls/sample-01_S1_L001_R1_001.fastq.gz",
-                        "/data/sequence/miseq/210101_M00123_0123_000000000-ABC123/Data/Intensities/BaseCalls/sample-01_S1_L001_R2_001.fastq.gz"
-                    ]
-                },
-                "sha256": {
-                    "type": "string",
-                    "description": "The checksum of a file, calculated with the SHA256 algorithm. Files with identical contents have identical checksums. If a single byte differs, the checksums will be completely different.",
-                    "examples":[
-                        "b0534592d61321243897e842a9ea655d396d4496cbf6d926b6c6fea8e06aa98d",
-                        "cc66309103da91e337143eb649196d84ed3ebe2ff08a45b197cd4151d137a167"
-                    ]
-                },
-		"file_size": {
-		    "type": "integer",
-		    "description": "Size of the file in bytes.",
-		    "examples": [
-			123456789,
-			1234567890
-		    ]
-		}
-	    },
-	    "required": [
-		"input_filename"
-	    ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "anyOf": [
+      {
+        "$ref": "#/definitions/PipelineProvenanceRecord",
+        "description": "A record of the pipeline that was run."
+      },
+      {
+        "$ref": "#/definitions/ProcessProvenanceRecord",
+        "description": "A record of a process that was run."
+      },
+      {
+        "$ref": "#/definitions/InputFileProvenanceRecord",
+        "description": "A record of an input file that was used."
+      },
+      {
+        "$ref": "#/definitions/OutputFileProvenanceRecord",
+        "description": "A record of an output file that was generated by the pipeline."
+      }
+    ]
+  },
+  "definitions": {
+    "PipelineProvenanceRecord": {
+      "title": "PipelineProvenanceRecord",
+      "type": "object",
+      "properties": {
+        "pipeline_name": {
+          "type": "string",
+          "description": "Name of the pipeline.",
+          "examples": [
+            "BCCDC-PHL/routine-assembly",
+            "BCCDC-PHL/plasmid-screen"
+          ]
+        },
+        "pipeline_version": {
+          "type": "string",
+          "description": "Version of the pipeline.",
+          "examples": [
+            "v0.1.0",
+            "0.1.0",
+            "1",
+            "2.0-beta"
+          ]
+        },
+        "timestamp_analysis_start": {
+          "type": "string",
+          "description": "Timestamp for the start of a pipeline run. ISO-8601-formatted date, followed by 'T' and a 24-hour timestamp, assumed to be in the local timezone if not specified. Timezone may be specified with an offset from UTC. Timestamp precision is not guaranteed.",
+          "format": "date-time",
+          "examples": [
+            "2021-12-06T16:12:31.252055",
+            "2022-01-12T01:22:51-08:00",
+            "2022-02-04T16:55:03.182-08:00"
+          ]
         }
+      },
+      "required": [
+        "pipeline_name",
+        "pipeline_version"
+      ]
+    },
+    "ProcessProvenanceRecord": {
+      "title": "ProcessProvenanceRecord",
+      "type": "object",
+      "properties": {
+        "process_name": {
+          "type": "string",
+          "description": "Name of the process.",
+          "examples": [
+            "fastp",
+            "bwa_mem",
+            "samtools_mpileup",
+            "align_reads_to_ref",
+            "trim_reads",
+            "CALL_VARIANTS"
+          ]
+        },
+        "tools": {
+          "type": "array",
+          "description": "The tools used to run the process.",
+          "items": {
+            "$ref": "#/definitions/Tool"
+          },
+          "examples": [
+            [
+              {
+                "tool_name": "fastp",
+                "tool_version": "0.20.0",
+                "subcommand": "trim",
+                "parameters": [
+                  {
+                    "parameter": "cut_tail",
+                    "value": null
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "tool_name": "bwa",
+                "tool_version": "0.7.17-r1188",
+                "subcommand": "mem",
+                "parameters": [
+                  {
+                    "parameter": "exclude_flags",
+                    "value": 1540
+                  },
+                  {
+                    "parameter": "min_base_quality",
+                    "value": 20
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      },
+      "required": [
+        "process_name"
+      ]
+    },
+    "Tool": {
+      "title": "Tool",
+      "type": "object",
+      "properties": {
+        "tool_name": {
+          "type": "string",
+          "description": "Name of the tool.",
+          "examples": [
+            "fastp",
+            "bwa",
+            "samtools",
+            "bcftools",
+            "medaka"
+          ]
+        },
+        "tool_version": {
+          "type": "string",
+          "description": "A number or string associated with a specific snapshot of the development state of a tool. Should (but may not always) map to a tagged release on GitHub or another version control system.",
+          "examples": [
+            "0.1.0",
+            "v0.1.1",
+            "1.1",
+            "2",
+            "0.7.17-r1188"
+          ]
+        },
+        "subcommand": {
+          "type": "string",
+          "description": "Subcommand of the tool.",
+          "examples": [
+            "mem",
+            "mpileup",
+            "filter"
+          ]
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ToolParameter"
+          },
+          "description": "The specific invocation of a process may depend on values that can be varied. These values are the parameters to that process. Each parameter has a name and a value.",
+          "examples": [
+            [
+              {
+                "parameter": "cut_tail",
+                "value": null
+              }
+            ],
+            [
+              {
+                "parameter": "exclude_flags",
+                "value": 1540
+              }
+            ],
+            [
+              {
+                "parameter": "min_base_quality",
+                "value": 20
+              }
+            ],
+            [
+              {
+                "parameter": "min_coverage",
+                "value": 10
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "ToolParameter": {
+      "title": "ToolParameter",
+      "type": "object",
+      "properties": {
+        "parameter": {
+          "type": "string",
+          "description": "Name of the parameter.",
+          "examples": [
+            "cut_tail",
+            "exclude_flags",
+            "min_base_quality",
+            "min_coverage"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value of the parameter, or null if the parameter is a flag without a value.",
+          "examples": [
+            "null",
+            "1540",
+            "20",
+            "10"
+          ]
+        }
+      },
+      "required": [
+        "parameter"
+      ]
+    },
+    "InputFileProvenanceRecord": {
+      "title": "InputFileProvenanceRecord",
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "filename"
+          ]
+        },
+        {
+          "required": [
+            "input_filename"
+          ]
+        }
+      ],
+      "properties": {
+        "input_filename": {
+          "type": "string",
+          "description": "Filename of an input file.",
+          "examples": [
+            "sample-01_R1.fastq.gz",
+            "sample-01_R2.fastq.gz",
+            "ref.fa",
+            "sample-01.bam",
+            "sample-01.bam.bai"
+          ]
+        },
+        "filename": {
+          "type": "string",
+          "description": "Filename of an input file. Alias for 'input_filename'.",
+          "examples": [
+            "sample-01_R1.fastq.gz",
+            "sample-01_R2.fastq.gz",
+            "ref.fa",
+            "sample-01.bam",
+            "sample-01.bam.bai"
+          ]
+        },
+        "file_path": {
+          "type": "string",
+          "description": "Absolute path to an input file, at the time that the pipeline was invoked. May be invalid if the input file is moved or renamed after pipeline invocation.",
+          "examples": [
+            "/data/ref_data/ecoli.fa",
+            "/data/sequence/miseq/210101_M00123_0123_000000000-ABC123/Data/Intensities/BaseCalls/sample-01_S1_L001_R1_001.fastq.gz",
+            "/data/sequence/miseq/210101_M00123_0123_000000000-ABC123/Data/Intensities/BaseCalls/sample-01_S1_L001_R2_001.fastq.gz"
+          ]
+        },
+        "sha256": {
+          "type": "string",
+          "description": "The checksum of a file, calculated with the SHA256 algorithm. Files with identical contents have identical checksums. If a single byte differs, the checksums will be completely different.",
+          "examples": [
+            "b0534592d61321243897e842a9ea655d396d4496cbf6d926b6c6fea8e06aa98d",
+            "cc66309103da91e337143eb649196d84ed3ebe2ff08a45b197cd4151d137a167"
+          ]
+        },
+        "file_size": {
+          "type": "integer",
+          "description": "Size of the file in bytes.",
+          "examples": [
+            123456789,
+            1234567890
+          ]
+        }
+      }
     }
+  },
+  "OutputFileProvenanceRecord": {
+    "title": "OutputFileProvenanceRecord",
+    "type": "object",
+    "properties": {
+      "output_filename": {
+        "type": "string",
+        "description": "Filename of an output file.",
+        "examples": [
+          "sample-01.bam",
+          "sample-01.bam.bai",
+          "sample-01.vcf",
+          "sample-01.vcf.gz"
+        ]
+      },
+      "filename": {
+        "type": "string",
+        "description": "Filename of an output file. Alias for 'output_filename'.",
+        "examples": [
+          "sample-01.bam",
+          "sample-01.bam.bai",
+          "sample-01.vcf",
+          "sample-01.vcf.gz"
+        ]
+      },
+      "file_path": {
+        "type": "string",
+        "description": "Absolute path to an output file, at the time that the pipeline was invoked. May be invalid if the output file is moved or renamed after pipeline invocation.",
+        "examples": [
+          "/data/analysis/outbreak_surveillance/210101_M00123_0123_000000000-ABC123/alignment-v0.1-output/sample-01/sample-01.bam",
+          "/data/analysis/outbreak_surveillance/210101_M00123_0123_000000000-ABC123/assembly-v0.1-output/sample-01/sample-01.fa"
+        ]
+      },
+      "sha256": {
+        "type": "string",
+        "description": "The checksum of a file, calculated with the SHA256 algorithm. Files with identical contents have identical checksums. If a single byte differs, the checksums will be completely different.",
+        "examples": [
+          "b0534592d61321243897e842a9ea655d396d4496cbf6d926b6c6fea8e06aa98d",
+          "cc66309103da91e337143eb649196d84ed3ebe2ff08a45b197cd4151d137a167"
+        ]
+      },
+      "file_size": {
+        "type": "integer",
+        "description": "Size of the file in bytes.",
+        "examples": [
+          123456789,
+          1234567890
+        ]
+      }
+    }
+  }
 }

--- a/schema/pipeline-provenance.json
+++ b/schema/pipeline-provenance.json
@@ -222,7 +222,7 @@
     "InputFileProvenanceRecord": {
       "title": "InputFileProvenanceRecord",
       "type": "object",
-      "anyOf": [
+      "oneOf": [
         {
           "required": [
             "filename"
@@ -288,6 +288,18 @@
   "OutputFileProvenanceRecord": {
     "title": "OutputFileProvenanceRecord",
     "type": "object",
+    "oneOf": [
+      {
+        "required": [
+          "filename"
+        ]
+      },
+      {
+        "required": [
+          "output_filename"
+        ]
+      }
+    ],
     "properties": {
       "output_filename": {
         "type": "string",


### PR DESCRIPTION
Fixes #4 

This adds a `OutputFileProvenanceRecord` type which is almost identical to `InputFileProvenanceRecord` except that it supports the `output_filename` attribute.

For both `InputFileProvenanceRecord` and `OutputFileProvenanceRecord`, the `filename` attribute can be used as an alternative to `input_filename` and `output_filename`, respectively.